### PR TITLE
Remove unnecessary into_iter

### DIFF
--- a/src/model/chord.rs
+++ b/src/model/chord.rs
@@ -35,8 +35,7 @@ mod tests {
     #[test]
     fn parser() {
         let chords: Vec<_> = Pitch::all()
-            .into_iter()
-            .flat_map(|pitch| Quality::iter().map(move |qquality| Chord::new(pitch, qquality)))
+            .flat_map(|pitch| Quality::iter().map(move |quality| Chord::new(pitch, quality)))
             .collect();
 
         let parsed: Vec<_> = chords


### PR DESCRIPTION
Per this comment, https://github.com/helixbass/line-runner/pull/8#discussion_r663377473 I could rename `Pitches::all()` as well, but I don't have any great ideas for a clearer name.