### PR TITLE
Line launcher: follow chord progression

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,6 @@ pub use model::{
     chord::Chord,
     letter::Letter,
     line::{Line, LineNote},
-    line_parser::parse_line,
     modifier::Modifier,
     pitch::Pitch,
     progression::Progression,

--- a/src/line_launcher/mod.rs
+++ b/src/line_launcher/mod.rs
@@ -3,7 +3,7 @@ use rand::Rng;
 use std::sync::mpsc::Receiver;
 use wmidi::{Channel, MidiMessage, Note, Velocity};
 
-use crate::{BeatNumber, Line};
+use crate::{BeatNumber, Line, Progression};
 
 #[derive(Clone, Copy, Debug)]
 enum State {
@@ -11,6 +11,7 @@ enum State {
     Playing {
         line_index: usize,
         next_note_index: usize,
+        pitch_offset: i8,
     },
 }
 
@@ -19,6 +20,7 @@ const VELOCITY: u8 = 100;
 
 pub struct LineLauncher {
     lines: Vec<Line>,
+    pub progression: Progression,
 }
 
 impl LineLauncher {
@@ -29,13 +31,19 @@ impl LineLauncher {
     ) {
         let mut midi_message_sender = MidiMessageSender { output };
         let mut state = State::NotPlaying;
+        let mut has_gotten_first_downbeat_message = false;
+        let mut chord_index: usize = 0;
         loop {
             let beat_message = beat_message_receiver.recv().unwrap();
+            if beat_message.is_beginning_of_measure() && has_gotten_first_downbeat_message {
+                chord_index = (chord_index + 1) % self.progression.chords.len();
+            }
             state = match state {
                 State::NotPlaying if beat_message.is_beginning_of_measure() => {
                     state = State::Playing {
                         line_index: rand::thread_rng().gen_range(0..self.lines.len()),
                         next_note_index: 0,
+                        pitch_offset: self.progression.chords[chord_index].pitch.index() as i8,
                     };
                     self.possibly_trigger_notes(state, &mut midi_message_sender, beat_message)
                 }
@@ -43,6 +51,9 @@ impl LineLauncher {
                     self.possibly_trigger_notes(state, &mut midi_message_sender, beat_message)
                 }
                 _ => state,
+            };
+            if !has_gotten_first_downbeat_message {
+                has_gotten_first_downbeat_message = true;
             }
         }
     }
@@ -57,6 +68,7 @@ impl LineLauncher {
             State::Playing {
                 line_index,
                 next_note_index,
+                pitch_offset,
             } => {
                 let line = &self.lines[line_index];
                 let mut did_trigger_note_off = false;
@@ -65,7 +77,8 @@ impl LineLauncher {
                     if beat_message.minus_sixteenths(last_played_note.duration)
                         == last_played_note.start
                     {
-                        midi_message_sender.fire_note_off(last_played_note.note);
+                        midi_message_sender
+                            .fire_note_off(last_played_note.note.step(pitch_offset).unwrap());
                         did_trigger_note_off = true;
                     }
                 }
@@ -78,10 +91,11 @@ impl LineLauncher {
                 }
                 let next_note = &line.notes[next_note_index];
                 if beat_message == next_note.start {
-                    midi_message_sender.fire_note_on(next_note.note);
+                    midi_message_sender.fire_note_on(next_note.note.step(pitch_offset).unwrap());
                     return State::Playing {
                         line_index,
                         next_note_index: next_note_index + 1,
+                        pitch_offset,
                     };
                 }
 
@@ -99,7 +113,10 @@ impl LineLauncher {
 
 impl Default for LineLauncher {
     fn default() -> Self {
-        Self { lines: Line::all() }
+        Self {
+            lines: Line::all(),
+            progression: Progression::default(),
+        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use midir::os::unix::{VirtualInput, VirtualOutput};
 use midir::{MidiInput, MidiOutput};
 use wmidi::MidiMessage;
 
-use line_runner::{LineLauncher, Message, MidiClockTracker};
+use line_runner::{LineLauncher, Message, MidiClockTracker, Progression};
 
 fn main() {
     let midi_out = MidiOutput::new("Line runner").unwrap();
@@ -25,7 +25,8 @@ fn main() {
         )
         .unwrap();
 
-    let line_launcher = LineLauncher::default();
+    let mut line_launcher = LineLauncher::default();
+    line_launcher.progression = Progression::parse("C C C C Eb Eb Eb Eb").unwrap();
     line_launcher.listen(beat_message_receiver, conn_out);
 }
 

--- a/src/model/line/mod.rs
+++ b/src/model/line/mod.rs
@@ -1,6 +1,8 @@
 use wmidi::Note;
 
-use crate::{parse_line, BeatNumber};
+use crate::{BeatNumber, Result};
+
+mod parser;
 
 #[derive(PartialEq, Debug)]
 pub struct LineNote {
@@ -26,7 +28,11 @@ impl Line {
             "C4 F3 G3 Bb3 C4 Db4 Bb3 Db4 C4 . .",
         ]
         .iter()
-        .map(|line_str| parse_line(line_str).unwrap())
+        .map(|line_str| Self::parse(line_str).unwrap())
         .collect()
+    }
+
+    pub fn parse(string: &str) -> Result<Self> {
+        parser::parse(string)
     }
 }

--- a/src/model/line/parser.rs
+++ b/src/model/line/parser.rs
@@ -42,7 +42,7 @@ impl Note {
     }
 }
 
-pub fn parse_line(line: &str) -> Result<Line> {
+pub fn parse(line: &str) -> Result<Line> {
     let octave_parser = (optional(token('-')), digit()).map(|(negative, digit)| {
         digit.to_string().parse::<i8>().unwrap() * negative.map_or(1, |_| -1)
     });
@@ -112,7 +112,7 @@ mod tests {
     #[test]
     fn it_parses_line_starting_on_downbeat() {
         assert_eq!(
-            parse_line("C4 F-1 G3 Bb3 C4 Db4 Eb4 F4 E4").unwrap(),
+            parse("C4 F-1 G3 Bb3 C4 Db4 Eb4 F4 E4").unwrap(),
             Line::new(vec![
                 LineNote {
                     start: BeatNumber { sixteenth_note: 0 },
@@ -166,7 +166,7 @@ mod tests {
     #[test]
     fn it_parses_sustain() {
         assert_eq!(
-            parse_line("C4 F3 G3 Bb3 C4 Db4 Eb4 F4 E4 . . .").unwrap(),
+            parse("C4 F3 G3 Bb3 C4 Db4 Eb4 F4 E4 . . .").unwrap(),
             Line::new(vec![
                 LineNote {
                     start: BeatNumber { sixteenth_note: 0 },
@@ -220,7 +220,7 @@ mod tests {
     #[test]
     fn it_parses_trailing_rests() {
         assert_eq!(
-            parse_line("C4 F3 G3 Bb3 C4 Db4 Eb4 F4 E4 . . . - -").unwrap(),
+            parse("C4 F3 G3 Bb3 C4 Db4 Eb4 F4 E4 . . . - -").unwrap(),
             Line::new(vec![
                 LineNote {
                     start: BeatNumber { sixteenth_note: 0 },
@@ -274,7 +274,7 @@ mod tests {
     #[test]
     fn it_parses_leading_rests() {
         assert_eq!(
-            parse_line("- Db4 Bb3 Db4 C4 . Bb3 G3 F3 Bb3 F3 Gb3 G3 Gb3 F3 G3 E3 . . .").unwrap(),
+            parse("- Db4 Bb3 Db4 C4 . Bb3 G3 F3 Bb3 F3 Gb3 G3 Gb3 F3 G3 E3 . . .").unwrap(),
             Line::new(vec![
                 LineNote {
                     start: BeatNumber { sixteenth_note: 1 },

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1,7 +1,6 @@
 pub mod chord;
 pub mod letter;
 pub mod line;
-pub mod line_parser;
 pub mod modifier;
 pub mod pitch;
 pub mod progression;

--- a/src/model/pitch.rs
+++ b/src/model/pitch.rs
@@ -24,6 +24,25 @@ impl Pitch {
     pub fn all() -> impl Iterator<Item = Pitch> {
         Letter::iter().flat_map(|l| Modifier::iter().map(move |m| Pitch::new(l, m)))
     }
+
+    pub fn index(&self) -> usize {
+        match (self.letter, self.modifier) {
+            (Letter::C, Modifier::Natural) => 0,
+            (Letter::D, Modifier::Flat) => 1,
+            (Letter::D, Modifier::Natural) => 2,
+            (Letter::E, Modifier::Flat) => 3,
+            (Letter::E, Modifier::Natural) => 4,
+            (Letter::F, Modifier::Flat) => 4,
+            (Letter::F, Modifier::Natural) => 5,
+            (Letter::G, Modifier::Flat) => 6,
+            (Letter::G, Modifier::Natural) => 7,
+            (Letter::A, Modifier::Flat) => 8,
+            (Letter::A, Modifier::Natural) => 9,
+            (Letter::B, Modifier::Flat) => 10,
+            (Letter::B, Modifier::Natural) => 11,
+            (Letter::C, Modifier::Flat) => 11,
+        }
+    }
 }
 
 impl fmt::Display for Pitch {
@@ -44,5 +63,10 @@ mod tests {
             .collect();
 
         assert_eq!(parsed, Pitch::all().collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn index() {
+        assert_eq!(Pitch::new(Letter::G, Modifier::Natural).index(), 7);
     }
 }

--- a/src/model/progression.rs
+++ b/src/model/progression.rs
@@ -1,4 +1,4 @@
-use crate::Chord;
+use crate::{Chord, Result};
 use combine::{parser::char::spaces, sep_by, Parser, Stream};
 use std::fmt;
 
@@ -20,6 +20,12 @@ impl Progression {
     {
         sep_by(Chord::parser(), spaces()).map(|chords: Vec<_>| Self::new(&chords))
     }
+
+    pub fn parse(string: &str) -> Result<Self> {
+        let (result, _) = Self::parser::<&str>().parse(string)?;
+
+        Ok(result)
+    }
 }
 
 impl fmt::Display for Progression {
@@ -39,12 +45,12 @@ mod tests {
     use super::*;
 
     #[test]
-    fn parser() {
+    fn parse() {
         let progressions = vec!["A Bm CM7 D7 Em7".to_string()];
 
         let parsed: Vec<_> = progressions
             .iter()
-            .map(|string| Progression::parser::<&str>().parse(string).unwrap().0)
+            .map(|string| Progression::parse(string).unwrap())
             .map(|s| s.to_string())
             .collect();
 

--- a/src/model/progression.rs
+++ b/src/model/progression.rs
@@ -40,6 +40,12 @@ impl fmt::Display for Progression {
     }
 }
 
+impl Default for Progression {
+    fn default() -> Self {
+        Self::parse("C").unwrap()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
In this PR:
- make `LineLauncher` accept a `Progression` and modify the key it plays lines in based on looping the progression

To test:
With the currently committed progression, you should hear it play four bars' worth of lines in C and then play four bars' worth of lines in Eb, then back