### PR TITLE
Note length as fraction of sixteenth note duration

### DIFF
--- a/src/line_launcher/mod.rs
+++ b/src/line_launcher/mod.rs
@@ -36,7 +36,7 @@ impl DurationBetweenSixteenthNotes {
         Self::Uninitialized
     }
 
-    pub fn process_beat_message(&mut self, _beat_message: &BeatNumber) -> Self {
+    pub fn process_beat_message(&self, _beat_message: &BeatNumber) -> Self {
         let now = SystemTime::now();
         match self {
             DurationBetweenSixteenthNotes::Uninitialized => {


### PR DESCRIPTION
In this PR:
- keep track of time between sixteenth notes and calculate the note length as a fraction of that time (currently hardcoded as half of that time)

To test:
You should hear rather short notes regardless of your BPM. If you change the hardcoded `0.5` multiplier you should hear correspondingly shorter/longer notes. If you push the multiplier past `1.0` it should sound the same as when there's no timing-based note-off being fired (ie legato) with the exception that notes that are specified as holding for longer than a sixteenth note will cut off based on the multiplier