### PR TITLE
Config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+config.yml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,6 +171,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dtoa"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
+
+[[package]]
 name = "getrandom"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -231,11 +237,18 @@ dependencies = [
  "num-traits",
  "rand",
  "serde",
+ "serde_yaml",
  "spin_sleep",
  "strum",
  "strum_macros",
  "wmidi",
 ]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "log"
@@ -431,6 +444,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.8.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15654ed4ab61726bf918a39cb8d98a2e2995b002387807fa6ba58fdf7f59bb23"
+dependencies = [
+ "dtoa",
+ "linked-hash-map",
+ "serde",
+ "yaml-rust",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -601,3 +626,12 @@ name = "wmidi"
 version = "4.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b7ff057a07cdcca1dce95859fb6e205dc99a9bc526d72f3d724468a12aa74a5"
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ midir = "0.7.0"
 num-traits = "0.2.14"
 rand = "0.8.4"
 serde = { version = "1.0.126", features = ["derive"] }
+serde_yaml = "0.8.17"
 spin_sleep = "1.0.0"
 strum = "0.21.0"
 strum_macros = "0.21.1"

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ midi:
   duration_ratio_slider:
     channel: 1
     control_change: 1 # modulation wheel
+# progression is optional, defaults to staying in the key of C
+progression: C C C C Eb Eb Eb Eb
 ```
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -1,0 +1,40 @@
+## Setup
+
+Install [`rustup`](https://rustup.rs/). Install the [`rust-analyzer`](https://rust-analyzer.github.io) language server if desired.
+
+## Formatting
+
+```shell
+cargo fmt
+```
+
+## Linting
+
+```shell
+cargo clippy
+```
+
+## Tests
+
+```shell
+cargo test
+```
+
+## Running
+
+Create a configuration file:
+
+```yaml
+# midi is optional
+midi:
+  port: # put any string here to have line-runner show you a list of available ports
+  # duration_ratio_slider is optional
+  duration_ratio_slider:
+    channel: 1
+    control_change: 1 # modulation wheel
+```
+
+```shell
+cargo run -- config.yml
+```
+

--- a/config.yml
+++ b/config.yml
@@ -1,0 +1,3 @@
+midi:
+  port: Launchkey Mini MK3 DAW Port
+  channel: 1

--- a/config.yml
+++ b/config.yml
@@ -1,3 +1,0 @@
-midi:
-  port: Launchkey Mini MK3 DAW Port
-  channel: 1

--- a/src/config/midi.rs
+++ b/src/config/midi.rs
@@ -1,8 +1,9 @@
 use crate::Result;
-// use serde::{Deserialize, Deserializer};
+use serde::Deserialize;
 use std::convert::TryInto;
 use wmidi::{Channel, ControlFunction, U7};
 
+#[derive(Debug, Deserialize)]
 pub struct Midi {
     pub port: Option<String>,
 }

--- a/src/config/midi.rs
+++ b/src/config/midi.rs
@@ -1,48 +1,47 @@
-use crate::Result;
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer};
 use std::convert::TryInto;
 use wmidi::{Channel, ControlFunction, U7};
 
 #[derive(Debug, Deserialize)]
 pub struct Midi {
     pub port: Option<String>,
+    pub duration_ratio_slider: Option<MidiSlider>,
 }
 
 impl Default for Midi {
     fn default() -> Self {
-        Self { port: None }
+        Self {
+            port: None,
+            duration_ratio_slider: None,
+        }
     }
 }
 
-#[derive(Copy, Clone, Debug /*Deserialize*/)]
+#[derive(Copy, Clone, Debug, Deserialize)]
 pub struct MidiSlider {
-    // #[serde(deserialize_with = "deserialize_channel")]
+    #[serde(deserialize_with = "deserialize_channel")]
     pub channel: Channel,
-    // #[serde(deserialize_with = "deserialize_control_function")]
+    #[serde(deserialize_with = "deserialize_control_function")]
     pub control_change: ControlFunction,
 }
 
-// fn deserialize_channel<'de, TDeserializer>(
-//     deserializer: TDeserializer,
-// ) -> std::result::Result<Channel, TDeserializer::Error>
-// where
-//     TDeserializer: Deserializer<'de>,
-// {
-//     let channel_number: u8 = Deserialize::deserialize(deserializer)?;
-//     Channel::from_index(channel_number - 1).map_err(serde::de::Error::custom)
-// }
+fn deserialize_channel<'de, TDeserializer>(
+    deserializer: TDeserializer,
+) -> std::result::Result<Channel, TDeserializer::Error>
+where
+    TDeserializer: Deserializer<'de>,
+{
+    let channel_number: u8 = Deserialize::deserialize(deserializer)?;
+    Channel::from_index(channel_number - 1).map_err(serde::de::Error::custom)
+}
 
-// fn deserialize_control_function<'de, TDeserializer>(
-//     deserializer: TDeserializer,
-// ) -> std::result::Result<ControlFunction, TDeserializer::Error>
-// where
-//     TDeserializer: Deserializer<'de>,
-// {
-//     let value_u8: u8 = Deserialize::deserialize(deserializer)?;
-//     u8_to_control_function(value_u8).map_err(serde::de::Error::custom)?
-// }
-
-pub fn u8_to_control_function(value: u8) -> Result<ControlFunction> {
-    let value_u7: U7 = value.try_into()?;
+fn deserialize_control_function<'de, TDeserializer>(
+    deserializer: TDeserializer,
+) -> std::result::Result<ControlFunction, TDeserializer::Error>
+where
+    TDeserializer: Deserializer<'de>,
+{
+    let value_u8: u8 = Deserialize::deserialize(deserializer)?;
+    let value_u7: U7 = value_u8.try_into().map_err(serde::de::Error::custom)?;
     Ok(value_u7.into())
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,1 +1,27 @@
 pub mod midi;
+
+use midi::Midi;
+
+use serde::Deserialize;
+
+use crate::Result;
+
+#[derive(Debug, Deserialize)]
+pub struct Config {
+    #[serde(default)]
+    pub midi: Midi,
+}
+
+impl Config {
+    pub fn from(yaml: &str) -> Result<Config> {
+        Ok(serde_yaml::from_str(yaml)?)
+    }
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            midi: Midi::default(),
+        }
+    }
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -4,12 +4,14 @@ use midi::Midi;
 
 use serde::Deserialize;
 
-use crate::Result;
+use crate::{Progression, Result};
 
 #[derive(Debug, Deserialize)]
 pub struct Config {
     #[serde(default)]
     pub midi: Midi,
+    #[serde(default)]
+    pub progression: Progression,
 }
 
 impl Config {
@@ -22,6 +24,7 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             midi: Midi::default(),
+            progression: Progression::default(),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ mod model;
 mod result;
 
 pub use beat_number::BeatNumber;
-pub use config::Config;
+pub use config::{midi::MidiSlider, Config};
 pub use line_launcher::LineLauncher;
 pub use midi::message::Message;
 pub use midi_clock_tracker::MidiClockTracker;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ mod model;
 mod result;
 
 pub use beat_number::BeatNumber;
+pub use config::Config;
 pub use line_launcher::LineLauncher;
 pub use midi::message::Message;
 pub use midi_clock_tracker::MidiClockTracker;

--- a/src/line_launcher/duration_slider_listener.rs
+++ b/src/line_launcher/duration_slider_listener.rs
@@ -1,19 +1,14 @@
-use crate::{config, config::midi::MidiSlider, midi, Message};
+use crate::{config::midi::MidiSlider, midi, Message};
 use bus::BusReader;
 use std::sync::mpsc::{self, Receiver};
 use std::thread;
-use wmidi::Channel;
 
 pub fn listen_for_duration_control_changes(
     mut midi_messages_receiver: BusReader<Message>,
+    slider: MidiSlider,
 ) -> Receiver<f64> {
     let (sender, receiver) = mpsc::channel();
     thread::spawn(move || {
-        let slider = MidiSlider {
-            channel: Channel::from_index(15).unwrap(),
-            control_change: config::midi::u8_to_control_function(28).unwrap(),
-        };
-
         for midi_message in midi_messages_receiver.iter() {
             if let Some(new_value) = control_value_ratio_from_midi_message(&midi_message, slider) {
                 sender.send(new_value).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use std::env;
 use std::fs;
 use wmidi::MidiMessage;
 
-use line_runner::{midi, Config, LineLauncher, Message, MidiClockTracker, Progression, Result};
+use line_runner::{midi, Config, LineLauncher, Message, MidiClockTracker, Result};
 
 fn main() -> Result<()> {
     let config = get_config()?;
@@ -43,8 +43,15 @@ fn main() -> Result<()> {
         None => None,
     };
 
-    let line_launcher: LineLauncher = Progression::parse("C C C C Eb Eb Eb Eb").unwrap().into();
-    line_launcher.listen(beat_message_receiver, conn_out, midi_messages, config);
+    let (progression, duration_ratio_slider) =
+        (config.progression, config.midi.duration_ratio_slider);
+    let line_launcher = LineLauncher::from(progression);
+    line_launcher.listen(
+        beat_message_receiver,
+        conn_out,
+        midi_messages,
+        duration_ratio_slider,
+    );
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,14 @@
 use midir::os::unix::{VirtualInput, VirtualOutput};
 use midir::{MidiInput, MidiOutput};
+use std::env;
+use std::fs;
 use wmidi::MidiMessage;
 
-use line_runner::{config, midi, LineLauncher, Message, MidiClockTracker, Progression, Result};
+use line_runner::{midi, Config, LineLauncher, Message, MidiClockTracker, Progression, Result};
 
 fn main() -> Result<()> {
+    let config = get_config()?;
+
     let midi_out = MidiOutput::new("Line runner").unwrap();
 
     let conn_out = midi_out.create_virtual("Line runner").unwrap();
@@ -25,16 +29,22 @@ fn main() -> Result<()> {
         )
         .unwrap();
 
-    let midi_config = config::midi::Midi {
-        port: Some("Launchkey Mini MK3 DAW Port".to_string()),
-    };
-    let midi_messages = match &midi_config.port {
+    let midi_port_names = midi::port_names()?;
+
+    if config.midi.port.is_none() && !midi_port_names.is_empty() {
+        println!(
+            "Config is missing 'midi.port'. Available MIDI ports are:\n{}",
+            midi_port_names.join("\n")
+        );
+    }
+
+    let midi_messages = match &config.midi.port {
         Some(port_name) => Some(midi::listen_for_input(port_name)?),
         None => None,
     };
 
     let line_launcher: LineLauncher = Progression::parse("C C C C Eb Eb Eb Eb").unwrap().into();
-    line_launcher.listen(beat_message_receiver, conn_out, midi_messages.unwrap());
+    line_launcher.listen(beat_message_receiver, conn_out, midi_messages);
 
     Ok(())
 }
@@ -43,4 +53,19 @@ fn handle_message(message: Message, midi_clock_tracker: &mut MidiClockTracker) {
     if message.message == MidiMessage::TimingClock {
         midi_clock_tracker.tick();
     }
+}
+
+fn get_config() -> Result<Config> {
+    let config = env::args()
+        .nth(1)
+        .map(|path| config_from_path(&path))
+        .transpose()?;
+    Ok(config.unwrap_or_default())
+}
+
+fn config_from_path(path: &str) -> Result<Config> {
+    println!("Reading config from {}", path);
+
+    let contents = fs::read_to_string(path)?;
+    Config::from(&contents)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,7 @@ fn main() -> Result<()> {
     };
 
     let line_launcher: LineLauncher = Progression::parse("C C C C Eb Eb Eb Eb").unwrap().into();
-    line_launcher.listen(beat_message_receiver, conn_out, midi_messages);
+    line_launcher.listen(beat_message_receiver, conn_out, midi_messages, config);
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use std::env;
 use std::fs;
 use wmidi::MidiMessage;
 
-use line_runner::{midi, Config, LineLauncher, Message, MidiClockTracker, Result};
+use line_runner::{config, midi, Config, LineLauncher, Message, MidiClockTracker, Result};
 
 fn main() -> Result<()> {
     let config = get_config()?;
@@ -43,8 +43,14 @@ fn main() -> Result<()> {
         None => None,
     };
 
-    let (progression, duration_ratio_slider) =
-        (config.progression, config.midi.duration_ratio_slider);
+    let Config {
+        progression,
+        midi: config::midi::Midi {
+            duration_ratio_slider,
+            ..
+        },
+        ..
+    } = config;
     let line_launcher = LineLauncher::from(progression);
     line_launcher.listen(
         beat_message_receiver,

--- a/src/midi/mod.rs
+++ b/src/midi/mod.rs
@@ -1,6 +1,6 @@
 pub mod message;
 
-use crate::{config::midi::MidiSlider, Message, Result};
+use crate::{Message, MidiSlider, Result};
 use anyhow::anyhow;
 use midir::{MidiInput, MidiInputPort};
 use num_traits::Num;

--- a/src/midi/mod.rs
+++ b/src/midi/mod.rs
@@ -20,7 +20,7 @@ pub fn listen_for_input(port_name: &str) -> Result<Receiver<Message>> {
     Ok(receiver)
 }
 
-fn port_names() -> Result<Vec<String>> {
+pub fn port_names() -> Result<Vec<String>> {
     let midi_input = midi_input()?;
     midi_input
         .ports()

--- a/src/model/progression.rs
+++ b/src/model/progression.rs
@@ -1,6 +1,6 @@
 use crate::{Chord, Result};
 use combine::{parser::char::spaces, sep_by, Parser, Stream};
-use serde::{Deserialize, Deserializer};
+use serde::{de, Deserialize, Deserializer};
 use std::fmt;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -55,7 +55,7 @@ impl<'de> Deserialize<'de> for Progression {
         TDeserializer: Deserializer<'de>,
     {
         let progression_string: String = Deserialize::deserialize(deserializer)?;
-        Ok(Progression::parse(&progression_string).unwrap())
+        Progression::parse(&progression_string).map_err(de::Error::custom)
     }
 }
 

--- a/src/model/progression.rs
+++ b/src/model/progression.rs
@@ -1,5 +1,6 @@
 use crate::{Chord, Result};
 use combine::{parser::char::spaces, sep_by, Parser, Stream};
+use serde::{Deserialize, Deserializer};
 use std::fmt;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -28,6 +29,12 @@ impl Progression {
     }
 }
 
+impl Default for Progression {
+    fn default() -> Self {
+        Self::parse("C").unwrap()
+    }
+}
+
 impl fmt::Display for Progression {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let string = self
@@ -37,6 +44,18 @@ impl fmt::Display for Progression {
             .collect::<Vec<_>>()
             .join(" ");
         f.write_str(&string)
+    }
+}
+
+impl<'de> Deserialize<'de> for Progression {
+    fn deserialize<TDeserializer>(
+        deserializer: TDeserializer,
+    ) -> std::result::Result<Self, TDeserializer::Error>
+    where
+        TDeserializer: Deserializer<'de>,
+    {
+        let progression_string: String = Deserialize::deserialize(deserializer)?;
+        Ok(Progression::parse(&progression_string).unwrap())
     }
 }
 


### PR DESCRIPTION
In this PR:
- support specifying MIDI port + slider for listening to duration ratio control changes and progression in config file

To test:
Per newly added README, if you create eg a `config.yml` with:
```
midi:
  port: Launchkey Mini MK3 DAW Port
  duration_ratio_slider:
    channel: 16
    control_change: 28
progression: C C C C Eb Eb Eb Eb
```
and run via `cargo run config.yml` it should behave the same as with those values previously hardcoded
If you comment out the `duration_ratio_slider` section of the config and re-run, it should behave the way it did before adding duration-ratio note-off'ing (eg sustaining notes for longer than a sixteenth note that are specified as held longer in the line definitions)

Based on `remove-duration-ratio-mutex`