### PR TITLE
Configure randomizing note start time

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ midi:
   ahead_or_behind_the_beat_ratio_slider:
     channel: 1
     control_change: 2
+  # randomize_note_start_time_ratio_slider is optional
+  randomize_note_start_time_ratio_slider:
+    channel: 1
+    control_change: 3
 # progression is optional, defaults to staying in the key of C
 progression: C C C C Eb Eb Eb Eb
 ```

--- a/src/config/midi.rs
+++ b/src/config/midi.rs
@@ -7,6 +7,7 @@ pub struct Midi {
     pub port: Option<String>,
     pub duration_ratio_slider: Option<MidiSlider>,
     pub ahead_or_behind_the_beat_ratio_slider: Option<MidiSlider>,
+    pub randomize_note_start_time_ratio_slider: Option<MidiSlider>,
 }
 
 impl Default for Midi {
@@ -15,6 +16,7 @@ impl Default for Midi {
             port: None,
             duration_ratio_slider: None,
             ahead_or_behind_the_beat_ratio_slider: None,
+            randomize_note_start_time_ratio_slider: None,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,6 +56,7 @@ fn main() -> Result<()> {
             config::midi::Midi {
                 duration_ratio_slider,
                 ahead_or_behind_the_beat_ratio_slider,
+                randomize_note_start_time_ratio_slider,
                 ..
             },
         ..
@@ -67,6 +68,7 @@ fn main() -> Result<()> {
         midi_messages,
         duration_ratio_slider,
         ahead_or_behind_the_beat_ratio_slider,
+        randomize_note_start_time_ratio_slider,
     );
 
     Ok(())


### PR DESCRIPTION
In this PR:
- expose configuration option to have MIDI slider control randomization of note start time

To test:
If per the updated README you add a `randomize_note_start_time_ratio_slider:` MIDI slider config to the `midi:` section in your config YAML file and while running adjust that slider, you should hear existing behavior (exact even-ness of note start times) when the slider is all the way to the left and increasing amounts of randomness to when the notes start as you turn the slider to the right

Based on `async-note-on`